### PR TITLE
Simplify Maven and Gradle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ For Apache Maven users, please add following to your pom.xml.
         <groupId>com.shekhargulati</groupId>
         <artifactId>strman</artifactId>
         <version>0.2.0</version>
-        <type>jar</type>
     </dependency>
 </dependencies>
 ```
@@ -24,9 +23,7 @@ For Apache Maven users, please add following to your pom.xml.
 Gradle users can add following to their build.gradle file.
 
 ```
-compile(group: 'com.shekhargulati', name: 'strman', version: '0.2.0', ext: 'jar'){
-        transitive=true
-}
+compile(group: 'com.shekhargulati', name: 'strman', version: '0.2.0')
 ```
 
 ## Available Functions


### PR DESCRIPTION
Classifier should not be needed for a JAR artifacts (have you experienced any issue with that?)